### PR TITLE
Fix: preserve numeric segments in path matching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /vendor/
 /.idea/
 *.cache
+.history

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /.idea/
 *.cache
 .history
+.phpactor.json

--- a/src/Http/Router.php
+++ b/src/Http/Router.php
@@ -123,7 +123,7 @@ class Router
             return null;
         }
 
-        $parts = array_values(array_filter(explode('/', $path), fn($segment) => $segment !== ''));
+        $parts = array_values(array_filter(explode('/', $path), fn ($segment) => $segment !== ''));
         $length = count($parts) - 1;
         $filteredParams = array_filter(self::$params, fn ($i) => $i <= $length);
 

--- a/src/Http/Router.php
+++ b/src/Http/Router.php
@@ -123,7 +123,7 @@ class Router
             return null;
         }
 
-        $parts = array_values(array_filter(explode('/', $path)));
+        $parts = array_values(array_filter(explode('/', $path), fn($segment) => $segment !== ''));
         $length = count($parts) - 1;
         $filteredParams = array_filter(self::$params, fn ($i) => $i <= $length);
 

--- a/tests/RouterTest.php
+++ b/tests/RouterTest.php
@@ -47,6 +47,7 @@ final class RouterTest extends TestCase
         $this->assertEquals($routeBlogAuthorsComments, Router::match(Http::REQUEST_METHOD_GET, '/blog/authors/comments'));
         $this->assertEquals($routeBlogPost, Router::match(Http::REQUEST_METHOD_GET, '/blog/test'));
         $this->assertEquals($routeBlogPostComments, Router::match(Http::REQUEST_METHOD_GET, '/blog/test/comments'));
+        $this->assertEquals($routeBlogPostCommentsSingle, Router::match(Http::REQUEST_METHOD_GET, '/blog/test/comments/0'));
         $this->assertEquals($routeBlogPostCommentsSingle, Router::match(Http::REQUEST_METHOD_GET, '/blog/test/comments/:comment'));
     }
 


### PR DESCRIPTION
This PR addresses an issue where numeric segments in the path, such as 0, were being filtered out due to the default behavior of array_filter.

**Before Change:** The segment 0 would be filtered out, potentially causing a 404 error or incorrect route matching.
**After Change:** The segment 0 is preserved, ensuring the correct route is matched.

The following changes have been made:

Updated the array_filter call to use a lambda function that filters out only empty strings, ensuring numeric segments like `0` are preserved.
Added a test case to verify that 0 is correctly matched in the path.