### PR TITLE
Update testing instructions in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,8 +67,9 @@ $ git push origin [name_of_your_new_branch]
 ### Testing
 
 - `docker compose up -d`
-- `docker compose exec web  vendor/bin/phpunit --configuration phpunit.xml`
-- `docker compose exec web vendor/bin/psalm --show-info=true`
+- `docker compose exec fpm vendor/bin/phpunit --configuration phpunit.xml`
+- `docker compose exec swoole vendor/bin/phpunit --configuration phpunit.xml`
+- `docker compose exec swoole-coroutine vendor/bin/phpunit --configuration phpunit.xml`
 
 ## Introducing New Features
 


### PR DESCRIPTION
This PR updates the testing instructions in the `CONTRIBUTING.md` file to reflect the current code implementation. The previous instructions were outdated and didn't run the tests. This update ensures that tests are run in the correct containers.

## Changes:
- Change testing instructions to use `fpm`
- Remove instructions for running PHPUnit and Psalm in the `web` container as it no longer matches the current implementation