### PR TITLE
fix: incorrect syntax for adding dependency to container

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ $user
     ->inject('request') // We can insert and use other injections as well
     ->setCallback(fn (Request $request) => $request->getHeader('x-user-id', 'John Doe'));
 
-$container->add($user);
+$container->set($user);
     
 // Defining Route    
 Http::get('/hello-world') 


### PR DESCRIPTION
updated to the correct syntax in `README.md` according to this -> https://github.com/utopia-php/di/blob/22490c95f7ac3898ed1c33f1b1b5dd577305ee31/src/DI/Container.php#L37