### PR TITLE
fix: implicit null warnings for test

### DIFF
--- a/src/Http/Adapter/FPM/Request.php
+++ b/src/Http/Adapter/FPM/Request.php
@@ -36,7 +36,7 @@ class Request extends UtopiaRequest
      * @param  string|null  $default
      * @return string|null
      */
-    public function getServer(string $key, string $default = null): ?string
+    public function getServer(string $key, ?string $default = null): ?string
     {
         return $_SERVER[$key] ?? $default;
     }

--- a/src/Http/Adapter/Swoole/Request.php
+++ b/src/Http/Adapter/Swoole/Request.php
@@ -43,7 +43,7 @@ class Request extends UtopiaRequest
      * @param  string|null  $default
      * @return string|null
      */
-    public function getServer(string $key, string $default = null): ?string
+    public function getServer(string $key, ?string $default = null): ?string
     {
         return $this->swoole->server[$key] ?? $default;
     }

--- a/src/Http/Adapter/Swoole/Server.php
+++ b/src/Http/Adapter/Swoole/Server.php
@@ -10,7 +10,7 @@ class Server extends Adapter
 {
     protected SwooleServer $server;
 
-    public function __construct(string $host, string $port = null, array $settings = [])
+    public function __construct(string $host, ?string $port = null, array $settings = [])
     {
         $this->server = new SwooleServer($host, $port);
         $this->server->set(\array_merge($settings, [

--- a/src/Http/Adapter/SwooleCoroutine/Server.php
+++ b/src/Http/Adapter/SwooleCoroutine/Server.php
@@ -9,7 +9,7 @@ class Server extends Adapter
 {
     protected SwooleServer $server;
 
-    public function __construct(string $host, string $port = null, array $settings = [])
+    public function __construct(string $host, ?string $port = null, array $settings = [])
     {
         $this->server = new SwooleServer($host, $port, false, true);
         $this->server->set(\array_merge($settings, [

--- a/src/Http/Files.php
+++ b/src/Http/Files.php
@@ -83,7 +83,7 @@ class Files
      *
      * @throws \Exception
      */
-    public function load(string $directory, string $root = null): void
+    public function load(string $directory, ?string $root = null): void
     {
         if (!is_readable($directory)) {
             throw new Exception("Failed to load directory: {$directory}");

--- a/src/Http/Http.php
+++ b/src/Http/Http.php
@@ -264,7 +264,7 @@ class Http extends Base
      *
      * @throws \Exception
      */
-    public function loadFiles(string $directory, string $root = null): void
+    public function loadFiles(string $directory, ?string $root = null): void
     {
         $this->files->load($directory, $root);
     }

--- a/src/Http/Request.php
+++ b/src/Http/Request.php
@@ -137,7 +137,7 @@ abstract class Request
      * @param  string|null  $default
      * @return string|null
      */
-    abstract public function getServer(string $key, string $default = null): ?string;
+    abstract public function getServer(string $key, ?string $default = null): ?string;
 
     /**
      * Set server

--- a/src/Http/Response.php
+++ b/src/Http/Response.php
@@ -364,7 +364,7 @@ abstract class Response
      * @param  string  $key
      * @param  string  $value
      */
-    public function addHeader(string $key, string $value): static
+    public function addHeader(string $key, ?string $value): static
     {
         $this->headers[$key] = $value;
 
@@ -413,7 +413,7 @@ abstract class Response
      * @param  bool  $httponly
      * @param  string  $sameSite
      */
-    public function addCookie(string $name, string $value = null, int $expire = null, string $path = null, string $domain = null, bool $secure = null, bool $httponly = null, string $sameSite = null): static
+    public function addCookie(string $name, ?string $value = null, ?int $expire = null, ?string $path = null, ?string $domain = null, ?bool $secure = null, ?bool $httponly = null, ?string $sameSite = null): static
     {
         $name = strtolower($name);
 

--- a/tests/HttpTest.php
+++ b/tests/HttpTest.php
@@ -578,7 +578,7 @@ class HttpTest extends TestCase
     /**
      * @dataProvider providerRouteMatching
      */
-    public function testCanMatchRoute(string $method, string $path, string $url = null): void
+    public function testCanMatchRoute(string $method, string $path, ?string $url = null): void
     {
         $url ??= $path;
         $expected = null;


### PR DESCRIPTION
fixes the warnings and errors generated due to implicit marking of null on various parameters