### PR TITLE
Fix: issue with matching null path and relevant test

### DIFF
--- a/src/Http/Http.php
+++ b/src/Http/Http.php
@@ -383,6 +383,11 @@ class Http extends Base
     public function match(Request $request): ?Route
     {
         $url = \parse_url($request->getURI(), PHP_URL_PATH);
+
+        if ($url === null || $url === false) {
+            $url = '/'; // Default to root path for malformed URLs
+        }
+
         $method = $request->getMethod();
         $method = (self::REQUEST_METHOD_HEAD == $method) ? self::REQUEST_METHOD_GET : $method;
 

--- a/tests/HttpTest.php
+++ b/tests/HttpTest.php
@@ -608,6 +608,58 @@ class HttpTest extends TestCase
         $this->assertEquals($expected, $route);
     }
 
+    public function testMatchWithNullPath(): void
+    {
+        // Create a route for root path
+        $expected = Http::get('/');
+
+        // Test case where parse_url returns null (malformed URL)
+        $_SERVER['REQUEST_METHOD'] = 'GET';
+        $_SERVER['REQUEST_URI'] = '?param=1'; // This will cause parse_url to return null for PATH component
+
+        $matched = $this->http->match(new Request());
+        $this->assertEquals($expected, $matched);
+    }
+
+    public function testMatchWithEmptyPath(): void
+    {
+        // Create a route for root path
+        $expected = Http::get('/');
+
+        // Test case where URI has no path component
+        $_SERVER['REQUEST_METHOD'] = 'GET';
+        $_SERVER['REQUEST_URI'] = 'https://example.com'; // No path component
+
+        $matched = $this->http->match(new Request());
+        $this->assertEquals($expected, $matched);
+    }
+
+    public function testMatchWithMalformedURL(): void
+    {
+        // Create a route for root path
+        $expected = Http::get('/');
+
+        // Test case where parse_url returns false (severely malformed URL)
+        $_SERVER['REQUEST_METHOD'] = 'GET';
+        $_SERVER['REQUEST_URI'] = '#fragment'; // Malformed scheme
+
+        $matched = $this->http->match(new Request());
+        $this->assertEquals($expected, $matched);
+    }
+
+    public function testMatchWithOnlyQueryString(): void
+    {
+        // Create a route for root path
+        $expected = Http::get('/');
+
+        // Test case where URI has only query string (no path)
+        $_SERVER['REQUEST_METHOD'] = 'GET';
+        $_SERVER['REQUEST_URI'] = '?param=value'; // Only query string, no path
+
+        $matched = $this->http->match(new Request());
+        $this->assertEquals($expected, $matched);
+    }
+
     public function testNoMismatchRoute(): void
     {
         $requests = [


### PR DESCRIPTION
Related: #171 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of malformed or missing URL paths, ensuring such requests are correctly routed to the root path instead of causing errors.

* **Tests**
  * Added new tests to verify correct routing behavior for requests with null, empty, or malformed URL paths, and for requests containing only a query string.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->