### PR TITLE
Fix: override default (backwards compatibility)

### DIFF
--- a/src/Response.php
+++ b/src/Response.php
@@ -542,7 +542,7 @@ class Response
      * @param  string  $value
      * @param  bool  $override
      */
-    public function addHeader(string $key, string $value, bool $override = false): static
+    public function addHeader(string $key, string $value, bool $override = true): static
     {
         if ($override) {
             $this->headers[$key] = $value;

--- a/tests/e2e/ResponseTest.php
+++ b/tests/e2e/ResponseTest.php
@@ -160,12 +160,12 @@ class ResponseTest extends TestCase
     {
         $response = $this->client->call(Client::METHOD_GET, '/set-cookie');
         $this->assertEquals(200, $response['headers']['status-code']);
-        $this->assertEquals('value1', $response['cookies']['key1']);
+        $this->assertArrayNotHasKey('key1', $response['cookies']);
         $this->assertEquals('value2', $response['cookies']['key2']);
 
-        $response = $this->client->call(Client::METHOD_GET, '/set-cookie-override');
+        $response = $this->client->call(Client::METHOD_GET, '/set-cookie-no-override');
         $this->assertEquals(200, $response['headers']['status-code']);
-        $this->assertArrayNotHasKey('key1', $response['cookies']);
+        $this->assertEquals('value1', $response['cookies']['key1']);
         $this->assertEquals('value2', $response['cookies']['key2']);
     }
 }

--- a/tests/e2e/server.php
+++ b/tests/e2e/server.php
@@ -42,12 +42,12 @@ App::get('/set-cookie')
         $response->send('OK');
     });
 
-App::get('/set-cookie-override')
+App::get('/set-cookie-no-override')
     ->inject('request')
     ->inject('response')
     ->action(function (Request $request, Response $response) {
-        $response->addHeader('Set-Cookie', 'key1=value1', override: true);
-        $response->addHeader('Set-Cookie', 'key2=value2', override: true);
+        $response->addHeader('Set-Cookie', 'key1=value1', override: false);
+        $response->addHeader('Set-Cookie', 'key2=value2', override: false);
         $response->send('OK');
     });
 


### PR DESCRIPTION
Marks default as true, which is how it behaved beforehand; this should prevent some rare issues, like  double CORS brought by community